### PR TITLE
Update to Crystal 0.35.1

### DIFF
--- a/src/scalingo01.cr
+++ b/src/scalingo01.cr
@@ -5,18 +5,19 @@ require "ecr/macros"
 bind = "0.0.0.0"
 port = 3000
 
-OptionParser.parse! do |opts|
+OptionParser.parse do |opts|
   opts.on("-p PORT", "--port PORT", "define port to run server") do |opt|
     port = opt.to_i
   end
 end
 
-server = HTTP::Server.new(bind, port) do |context|
+server = HTTP::Server.new do |context|
   context.response.content_type = "text/html"
-	io = IO::Memory.new
+  io = IO::Memory.new
   ECR.embed "tpl/home.ecr", io
   context.response << io.to_s
 end
 
-puts "Listening on http://#{bind}:#{port}"
+address = server.bind_tcp bind, port
+puts "Listening on http://#{address}"
 server.listen


### PR DESCRIPTION
trying to execute the example leads to some errors, starting with:

```
In src/scalingo01.cr:14:23

 14 | server = HTTP::Server.new(bind, port) do |context|
                            ^--
Error: wrong number of arguments for 'HTTP::Server.new' (given 2, expected 0..1)

Overloads are:
 - HTTP::Server.new(handlers : Array(HTTP::Handler), &handler)
 - HTTP::Server.new(&handler)
 - HTTP::Server.new(handlers : Array(HTTP::Handler))
 - HTTP::Server.new(handler : HTTP::Handler | HTTP::Handler::HandlerProc)
```
and more...

I have fixed them. Please review the changes and merge if you want.
